### PR TITLE
Add secure verification, email-linking endpoints and schema alignment

### DIFF
--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -422,6 +422,17 @@ button:disabled {
   color: var(--text-primary);
 }
 
+.email-btn {
+  background: rgba(59, 130, 246, 0.12);
+  color: #93c5fd;
+  border: 1px solid rgba(59, 130, 246, 0.3) !important;
+}
+
+.email-btn:hover {
+  background: rgba(59, 130, 246, 0.22);
+  box-shadow: 0 0 12px rgba(59, 130, 246, 0.2);
+}
+
 /* --- Locked State --- */
 
 .letter-card.locked {
@@ -495,6 +506,50 @@ button:disabled {
   color: #f87171;
 }
 
+.verification-card.gated .status-header {
+  color: #a5b4fc;
+}
+
+.verification-message {
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.verification-form {
+  display: flex;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.verification-form input {
+  flex: 1;
+  padding: 0.8rem 1rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: rgba(0, 0, 0, 0.4);
+  color: var(--text-primary);
+}
+
+.verify-btn {
+  border: none;
+  background: var(--accent);
+  color: #0b0b12;
+  font-weight: 700;
+  padding: 0.8rem 1.2rem;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.verify-btn:hover {
+  box-shadow: 0 0 18px var(--accent-glow);
+}
+
+.error-text {
+  color: #f87171;
+  font-size: 0.85rem;
+  margin-bottom: 1.5rem;
+}
+
 .details {
   background: rgba(0, 0, 0, 0.3);
   padding: 2rem;
@@ -543,6 +598,28 @@ button:disabled {
 }
 
 .audit-table {
+  overflow-x: auto;
+}
+
+.email-links {
+  margin-top: 2.5rem;
+}
+
+.email-links h3 {
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  letter-spacing: 0.08em;
+  margin-bottom: 0.5rem;
+}
+
+.email-links p {
+  color: var(--text-secondary);
+  margin-bottom: 1rem;
+  font-size: 0.85rem;
+}
+
+.email-table {
   overflow-x: auto;
 }
 

--- a/supabase/migrations/20260201_align_schema_and_email_links.sql
+++ b/supabase/migrations/20260201_align_schema_and_email_links.sql
@@ -1,0 +1,61 @@
+-- Align schema with issuance API and add email classifier linkage
+
+-- Letters: add content and source IP capture
+ALTER TABLE letters
+    ADD COLUMN content TEXT NOT NULL DEFAULT '',
+    ADD COLUMN source_ip INET;
+
+-- Approvals: link directly to letters and capture source IP
+ALTER TABLE approvals
+    ADD COLUMN letter_id UUID;
+
+UPDATE approvals
+SET letter_id = letter_versions.letter_id
+FROM letter_versions
+WHERE approvals.letter_version_id = letter_versions.id;
+
+ALTER TABLE approvals
+    ALTER COLUMN letter_id SET NOT NULL;
+
+ALTER TABLE approvals
+    DROP COLUMN letter_version_id,
+    ADD COLUMN source_ip INET;
+
+-- Issuances: persist content hash for verification lookup
+ALTER TABLE issuances
+    ADD COLUMN content_hash TEXT;
+
+UPDATE issuances
+SET content_hash = letter_versions.content_hash
+FROM letter_versions
+WHERE issuances.letter_version_id = letter_versions.id;
+
+ALTER TABLE issuances
+    ALTER COLUMN content_hash SET NOT NULL;
+
+-- Print audits: add status for tracking
+ALTER TABLE print_audits
+    ADD COLUMN status TEXT DEFAULT 'SUCCESS';
+
+-- Acknowledgements: store source IP
+ALTER TABLE acknowledgements
+    ADD COLUMN source_ip INET;
+
+-- Email classifier linkage table
+CREATE TABLE email_links (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    letter_id UUID REFERENCES letters(id) ON DELETE SET NULL,
+    job_reference TEXT,
+    sender TEXT,
+    subject TEXT,
+    body_excerpt TEXT,
+    received_at TIMESTAMPTZ,
+    classified_by UUID REFERENCES auth.users(id),
+    source_ip INET,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+ALTER TABLE email_links ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Internal Read Access" ON email_links FOR SELECT TO authenticated USING (true);
+CREATE POLICY "Internal Insert Access" ON email_links FOR INSERT TO authenticated WITH CHECK (true);


### PR DESCRIPTION
### Motivation
- Enable controlled (non-public) QR/hash verification and richer verification responses for issued letters. 
- Capture and persist issuance/print metadata (content hash, source IP, printer) for auditability and validation.
- Add inbound email→letter linkage so an email classifier or operator can attach customer emails to letters/jobs for faster resolution.

### Description
- API: added gated verification endpoint (`GET /api/verify/:hash`) that honors `VERIFIED_ACCESS_KEY` via `x-verify-key` and uses `buildVerificationResponse` for consistent responses. 
- API: record `content_hash` on `issuances`, persist `source_ip` for approvals/prints/acknowledgements, changed print audit insertion to `print_audits`, and insert richer `audit_logs` metadata. 
- API: added email linkage endpoints `GET /api/email-links` and `POST /api/email-links` that store classifier matches and append `EMAIL_LINK` entries to `audit_logs`. 
- Web UI: added verification-gate UI to request access key when necessary, implemented client flows for verifying via `x-verify-key`, added per-letter `Link Email` action and an `Email Classifier Linkage` table in the Audit view. 
- DB: new migration `supabase/migrations/20260201_align_schema_and_email_links.sql` to align schema (add `content`, `source_ip`, `content_hash`, `status` on audits) and create `email_links` table with RLS/policies. 
- Styling: updated CSS to support gated verification UI and new email-link action/table styles.

### Testing
- Started the frontend dev server with `npm run dev`; the server became available (Vite reported ready) but PostCSS plugin loading warnings/errors were emitted in the dev console. 
- Captured a UI artifact by launching the app and taking a screenshot using Playwright; screenshot generation succeeded and an artifact was produced. 
- No automated unit tests were executed as part of this rollout (existing tests in `apps/api/src/*.test.ts` were not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969fc3581c08330bd8cc09869e9fc60)